### PR TITLE
Fixed URL type issue

### DIFF
--- a/BrowseOntology/Tutorial browsing eNM ontology.md
+++ b/BrowseOntology/Tutorial browsing eNM ontology.md
@@ -35,9 +35,7 @@ trainingMaterial:
   difficultyLevel: [Beginner]
   keywords: nanotoxicology, Ontologies, BioPortal, AberOWL, Protégé
   license: CC-BY 4.0
-  url:
-    - "@type": URL
-      url: https://enanomapper.github.io/tutorials/BrowseOntology/Tutorial%20browsing%20eNM%20ontology.html
+  url: https://enanomapper.github.io/tutorials/BrowseOntology/Tutorial%20browsing%20eNM%20ontology.html
   version: 1.1.1
 ---
 

--- a/Entering_and_analysing_nano_safety_data/readme.md
+++ b/Entering_and_analysing_nano_safety_data/readme.md
@@ -34,9 +34,7 @@ trainingMaterial:
   difficultyLevel: [Intermediate]
   keywords: ontologies, enanomapper
   license: CC-BY 4.0
-  url:
-    - "@type": URL
-      url: https://enanomapper.github.io/tutorials/Entering_and_analysing_nano_safety_data/readme.html
+  url: https://enanomapper.github.io/tutorials/Entering_and_analysing_nano_safety_data/readme.html
   version: 1.0
 ---
 


### PR DESCRIPTION
The way to display the URL field in schema.org is as a text string e.g. url: <myURL>

The documentation is a bit confusing because it says that a url field is type Url... So you might expect to use a new type to define it. But the correct usage is a standard text field. Some examples of it can be found here: https://schema.org/url
