### PR TITLE
Replace CreativeWork with LearningResource

### DIFF
--- a/Added ontology terms/README.md
+++ b/Added ontology terms/README.md
@@ -3,11 +3,11 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   "@id": https://enanomapper.github.io/tutorials/Added%20ontology%20terms/
   "http://purl.org/dc/terms/conformsTo":
     - "@id": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE"
-      "@type": "CreativeWork"
+      "@type": "LearningResource"
   description: "This tutorial describes how terms can be added to the eNanoMapper ontology."
   audience:
     - "@type": Audience

--- a/BrowseOntology/Tutorial browsing eNM ontology.md
+++ b/BrowseOntology/Tutorial browsing eNM ontology.md
@@ -3,10 +3,10 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   "http://purl.org/dc/terms/conformsTo":
     - "@id": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE"
-      "@type": "CreativeWork"
+      "@type": "LearningResource"
   "@id": https://enanomapper.github.io/tutorials/BrowseOntology/Tutorial%20browsing%20eNM%20ontology.html
   description: "This tutorial explains how the eNanoMapper ontology can be browsed with three tools, of which two are online."
   audience:

--- a/Entering_and_analysing_nano_safety_data/readme.md
+++ b/Entering_and_analysing_nano_safety_data/readme.md
@@ -3,12 +3,12 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   "@id": https://enanomapper.github.io/tutorials/Entering_and_analysing_nano_safety_data/
   description: "Tutorial that covers various aspects of working with the eNanoMapper database. It discussed searching, adding, and downloading data from an eNanoMapper database."
   "http://purl.org/dc/terms/conformsTo":
     - "@id": "https://bioschemas.org/profiles/TrainingMaterial/1.0-RELEASE"
-      "@type": "CreativeWork"
+      "@type": "LearningResource"
   audience:
     - "@type": Audience
       name: PhD students

--- a/Omics descriptors calculation/Omics descriptors calculation R package.md
+++ b/Omics descriptors calculation/Omics descriptors calculation R package.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to generate a new set of GO descriptors using two novel created R packages."
   audience:
     - "@type": Audience

--- a/Pathway/Pathway.md
+++ b/Pathway/Pathway.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to a new pathway for WikiPathways using PathVisio."
   audience:
     - "@type": Audience

--- a/Pathway/readme.md
+++ b/Pathway/readme.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial describes how to draw new machine readable pathways."
   audience:
     - "@type": Audience

--- a/Pathway_analysis/Pathway analysis.md
+++ b/Pathway_analysis/Pathway analysis.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to use the Pathway module of ArrayAnalysis.org for pathway analysis of microarray data."
   audience:
     - "@type": Audience

--- a/Pathway_analysis/readme.md
+++ b/Pathway_analysis/readme.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial describes how to perform pathway analysis."
   audience:
     - "@type": Audience

--- a/QCandpreprocessing/QCandpreprocessing.md
+++ b/QCandpreprocessing/QCandpreprocessing.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to use the AffyQC web tool of ArrayAnalysis.org for quality control and pre-processing of Affymetrix microarray data."
   audience:
     - "@type": Audience

--- a/RRegrs/RRegrs.md
+++ b/RRegrs/RRegrs.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to use a collection of R regression tools for estimating the optimal model via a fully validated procedure."
   audience:
     - "@type": Audience

--- a/Statistics/Statistics.md
+++ b/Statistics/Statistics.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial explains how to use the statistics module of ArrayAnalysis.org for statistics analysis of microarray data."
   audience:
     - "@type": Audience

--- a/Statistics/readme.md
+++ b/Statistics/readme.md
@@ -3,7 +3,7 @@ layout: default
 
 trainingMaterial:
   "@context": http://schema.org/
-  "@type": CreativeWork
+  "@type": LearningResource
   about: "This tutorial how to statistically analyze microarray data with ArrayAnalysis.org website."
   audience:
     - "@type": Audience


### PR DESCRIPTION
The correct type on schema.org is LearningResource. This allows TeSS to see the properties of the LearningResource type that are not part of its parent CreativeWork.

We also need to set up TeSS to see the sitemap.xml again. I will message @egonw directly about this in Slack.